### PR TITLE
RDO-2001 : Update Jenkins job config from template whenever template more recent

### DIFF
--- a/tasks/job.yml
+++ b/tasks/job.yml
@@ -29,6 +29,24 @@
   tags:
     - jenkins-jobs
 
+- name: Get mtime for job template file
+  stat:
+    path: "{{ this_job_full_path }}.template"
+  register: statfile1
+
+- name: Get mtime for job configuration file
+  stat:
+    path: "{{ this_job_full_path }}"
+  register: statfile2
+
+- name: Show statfile1
+  debug:
+    var=statfile1
+
+- name: Show statfile2
+  debug:
+    var=statfile2
+
 - name: Create {{ job.name }} job
   shell: |
     if {{ jenkins_role_cli_command }} list-jobs | grep "^{{ job.name }}$"; then
@@ -39,7 +57,7 @@
   become: yes
   become_user: jenkins
   when:
-    - job_template_file.changed
+    - statfile2.stat.exists == false or statfile1.stat.mtime > statfile2.stat.mtime
     - ansible_virtualization_type != "docker"
   tags:
     - jenkins-jobs


### PR DESCRIPTION
Update Jenkins job config from template whenever template more recent than than job config.
We got problem when a job was not being updated but the template file was up to date. It can happen if the Jenkins job fails. The next time the job is run it would not update the Jenkins job as the state would not be "changed" this time. With the fix the Jenkins job configuration will be reloaded whenever the template is more recent than the job configuration, so it should never leave jobs with an old configuration,